### PR TITLE
Add blocklist feature

### DIFF
--- a/config/redirects.php
+++ b/config/redirects.php
@@ -25,4 +25,18 @@ return [
         // '/old' => '/new',
         // 'blog/{url}' => 'news/{url}',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect blocklist
+    |--------------------------------------------------------------------------
+    |
+    | You may configure routes that should never be redirected, such as backend
+    | routes or similar.
+    |
+    */
+
+    'blocklist' => [
+        // '/admin',
+    ],
 ];

--- a/src/RedirectRouter.php
+++ b/src/RedirectRouter.php
@@ -7,6 +7,7 @@ use Carbon\CarbonInterval;
 use Exception;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Request;
 
 class RedirectRouter
@@ -30,11 +31,32 @@ class RedirectRouter
      */
     public function getRedirectFor(Request $request)
     {
+        if ($this->requestIsBlockedForRedirect($request)) {
+            return;
+        }
+
         if (! $redirects = $this->getRedirects()) {
             return;
         }
 
         return $this->handleRedirect($request, $redirects);
+    }
+
+    /**
+     * Determine if a request is blocked for redirection.
+     *
+     * @param  Request $request
+     * @return bool
+     */
+    protected function requestIsBlockedForRedirect($request)
+    {
+        foreach (config('redirects.blocklist') as $blocked) {
+            if (Str::contains($blocked, $request->path())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/RedirectRouter.php
+++ b/src/RedirectRouter.php
@@ -51,9 +51,9 @@ class RedirectRouter
     protected function requestIsBlockedForRedirect($request)
     {
         foreach (config('redirects.blocklist') as $blocked) {
-            if (Str::contains($blocked, $request->path())) {
-                return true;
-            }
+            $blocked = Str::of($blocked)->ltrim('/');
+
+            return Str::is($blocked, $request->path());
         }
 
         return false;

--- a/tests/RedirectBlocklistTest.php
+++ b/tests/RedirectBlocklistTest.php
@@ -26,4 +26,22 @@ class RedirectBlocklistTest extends TestCase
         $response = $this->get('admin');
         $response->assertSee('admin backend');
     }
+
+    public function test_blocklist_respects_wildcards()
+    {
+        $this->app['config']->set('redirects.blocklist', [
+            '/admin/*',
+        ]);
+
+        $this->app['config']->set('redirects.redirects', [
+            '/{url}' => 'de/{url}',
+        ]);
+
+        Route::get('admin/foo', function () {
+            return 'admin foo';
+        });
+
+        $response = $this->get('admin/foo');
+        $response->assertSee('admin foo');
+    }
 }

--- a/tests/RedirectBlocklistTest.php
+++ b/tests/RedirectBlocklistTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AwStudio\Redirects\Tests;
+
+use Illuminate\Support\Facades\Route;
+
+class RedirectBlocklistTest extends TestCase
+{
+    public function test_it_will_not_redirect_blocked_routes()
+    {
+        $this->app['config']->set('redirects.blocklist', [
+            '/admin',
+        ]);
+
+        $this->app['config']->set('redirects.redirects', [
+            '/{url}' => 'de/{url}',
+        ]);
+
+        Route::get('admin', function () {
+            return 'admin backend';
+        });
+
+        $response = $this->get('/foo');
+        $response->assertRedirect('de/foo');
+
+        $response = $this->get('admin');
+        $response->assertSee('admin backend');
+    }
+}


### PR DESCRIPTION
This PR adds the opportunity to define routes that should be protected from accidental redirects.

This is useful if you want to redirect your entire frontend for SEO reasons, for example from `/` to `/en`, but leave some routes untouched, like `/admin`  or similar.