### PR TITLE
use model from config instead of hardcoded model

### DIFF
--- a/src/RedirectsServiceProvider.php
+++ b/src/RedirectsServiceProvider.php
@@ -15,9 +15,9 @@ class RedirectsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->alias(Redirect::class, 'redirect.model');
-
         $this->mergeConfigFrom(__DIR__ . '/../config/redirects.php', 'redirects');
+
+        $this->app->alias(config('redirects.model'), 'redirect.model');
     }
 
     /**


### PR DESCRIPTION
When trying to override the Redirect Model from the package with your own Model by changing the model in the redirects config, the new Model would not be used. This PR fixes this problem.